### PR TITLE
Update multiFileUpload.js

### DIFF
--- a/js/multiFileUpload.js
+++ b/js/multiFileUpload.js
@@ -24,28 +24,34 @@
             }
           };
 
-          function replacePlaceHolder(templateStr, index)
-          {
-            var fileName = null;
-            index = String(index);
+          function replacePlaceHolder(templateStr, index) {
+             var fileName = null;
 
+            var complex_matchs = templateStr.match(/\%(d+) (\d+)\%/);
             var matches = templateStr.match(/\%(d+)\%/);
-
-            if (null != matches && 0 < matches[1].length)
-            {
-              while (matches[1].length > index.length)
-              {
+            
+            if (null != complex_matchs && 0 < complex_matchs[2].length) {
+              index = String(index - 1 + parseInt(complex_matchs[2]));
+              
+              while (complex_matchs[1].length > index.length) {
                 index = '0' + index;
               }
-
+              
+              var fileName = templateStr.replace('%' + complex_matchs[1] + ' ' + complex_matchs[2] + '%', index);
+            
+            } else if (null != matches && 0 < matches[1].length) {
+              index = String(index);
+              while (matches[1].length > index.length) {
+                index = '0' + index;
+              }
+              
               var fileName = templateStr.replace('%' + matches[1] + '%', index);
             }
-
-            if (null == fileName || templateStr == fileName)
-            {
+            
+            if (null == fileName || templateStr == fileName) {
               fileName = templateStr + ' ' + index;
             }
-
+            
             return fileName;
           }
 


### PR DESCRIPTION
Added an additional regular expression to the file renaming process to enable a more complex auto incrementing scheme. The original functionality is intact: 
With no user specified numbering scheme, sequential numbers are appended to the end of the filename string.
If the user specifies the %ddd% notation - then the numbers are padded out with leading zeros in the resultant string.

**New functionality:**
The user can specify the starting number for the incrementing scheme by putting it into the regex, so to start counting from 101 (instead of 1) the user would use the form: %ddd 101% - add a space after the placeholder markers and then instruct the method with the starting offset.

This pull request is the result of a user who needed to upload batches of files from different folders on their workstation, or at different times. The existing upload process would duplicate names. They were either manually editing names (in the UI, or with a CSV extract and import process) or pre-appending a digit before the %ddd% notation, but both solutions were not ideal.

This is a small change, and it may not be the best implementation. I do however think it is a useful and could be expanded for further niche naming systems in future versions. Like alphabetic, hexadecimal or perhaps a barcode or hashed serial number.